### PR TITLE
Calculate offsets for cex trades based on block time configuration

### DIFF
--- a/crates/bin/src/executors/shared/metadata_loader.rs
+++ b/crates/bin/src/executors/shared/metadata_loader.rs
@@ -12,6 +12,7 @@ use std::{
 use alloy_primitives::Address;
 use brontes_database::clickhouse::ClickhouseHandle;
 use brontes_types::{
+    constants::BLOCK_TIME_MILLIS,
     db::{
         cex::trades::{window_loader::CexWindow, CexTradeMap},
         dex::DexQuotes,
@@ -132,7 +133,7 @@ impl<T: TracingProvider, CH: ClickhouseHandle> MetadataLoader<T, CH> {
             let window = self.cex_window_data.get_window_lookahead();
             // given every download is -6 + 6 around the block
             // we calculate the offset from the current block that we need
-            let offsets = (window / 12) as u64;
+            let offsets = (window * 1000 / BLOCK_TIME_MILLIS) as u64;
             let mut trades = Vec::new();
             for block in block - offsets..=block + offsets {
                 if let Ok(res) = libmdbx.get_cex_trades(block) {
@@ -256,7 +257,7 @@ impl<T: TracingProvider, CH: ClickhouseHandle> MetadataLoader<T, CH> {
         let window = self.cex_window_data.get_window_lookahead();
         // given every download is -6 + 6 around the block
         // we calculate the offset from the current block that we need
-        let offsets = (window / 12) as u64;
+        let offsets = (window * 1000 / BLOCK_TIME_MILLIS) as u64;
         let future = Box::pin(async move {
             let builder_info = libmdbx
                 .try_fetch_builder_info(tree.header.beneficiary)

--- a/crates/brontes-types/src/constants/arbitrum.rs
+++ b/crates/brontes-types/src/constants/arbitrum.rs
@@ -1,5 +1,7 @@
 use alloy_primitives::{hex, Address};
 
+pub const BLOCK_TIME_MILLIS: usize = 250;
+
 pub const USDT_ADDRESS_STRING: &str = "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9";
 // USD Stablecoins
 pub const USDT_ADDRESS: Address = Address::new(hex!("Fd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"));

--- a/crates/brontes-types/src/constants/mainnet.rs
+++ b/crates/brontes-types/src/constants/mainnet.rs
@@ -1,5 +1,8 @@
 use alloy_primitives::{hex, Address};
 
+
+pub const BLOCK_TIME_MILLIS: usize = 12_000;
+
 pub const USDT_ADDRESS_STRING: &str = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
 
 pub const ETH_ADDRESS: Address = Address::new(hex!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"));


### PR DESCRIPTION
 - Arbitrum needs to inspect multiple blocks to get the trades correctly according to the cex window size configured.
 - Current implementation was using a fixed value of 12 seconds for the block time, which is not correct for Arbitrum.