### PR TITLE
Implement Clickhouse token info read

### DIFF
--- a/crates/brontes-database/brontes-db/src/clickhouse/db_client.rs
+++ b/crates/brontes-database/brontes-db/src/clickhouse/db_client.rs
@@ -48,7 +48,7 @@ use tracing::{debug, error, warn};
 
 use super::{
     cex_config::CexDownloadConfig, dbms::*, ClickhouseHandle, MOST_VOLUME_PAIR_EXCHANGE,
-    P2P_OBSERVATIONS, PRIVATE_FLOW, RAW_CEX_QUOTES, RAW_CEX_TRADES,
+    P2P_OBSERVATIONS, PRIVATE_FLOW, RAW_CEX_QUOTES, RAW_CEX_TRADES, TOKEN_INFO,
 };
 #[cfg(feature = "local-clickhouse")]
 use super::{BLOCK_TIMES, CEX_SYMBOLS};
@@ -429,6 +429,19 @@ impl Clickhouse {
             .run_with(self.query_optional_with_retry::<u64, _>(
                 P2P_OBSERVATIONS,
                 &(block_number, format!("{:?}", block_hash).to_lowercase()),
+            ))
+            .await?)
+    }
+
+    pub async fn get_token_info(
+        &self,
+        address: Address,
+    ) -> eyre::Result<Option<TokenInfoWithAddress>> {
+        Ok(self
+            .rate_limiter
+            .run_with(self.query_optional_with_retry::<TokenInfoWithAddress, _>(
+                TOKEN_INFO,
+                &(format!("{:?}", address).to_lowercase()),
             ))
             .await?)
     }

--- a/crates/brontes-database/brontes-db/src/clickhouse/middleware.rs
+++ b/crates/brontes-database/brontes-db/src/clickhouse/middleware.rs
@@ -1,3 +1,4 @@
+use std::pin::Pin;
 use std::sync::Arc;
 
 use alloy_primitives::Address;
@@ -22,6 +23,7 @@ use brontes_types::{
     BlockTree, FastHashMap, Protocol,
 };
 use indicatif::ProgressBar;
+use futures::Future;
 
 use super::Clickhouse;
 use crate::{
@@ -359,14 +361,17 @@ impl<I: LibmdbxInit> LibmdbxReader for ClickhouseMiddleware<I> {
         self.inner.get_dex_quotes(block)
     }
 
-    fn try_fetch_token_info(&self, address: Address) -> eyre::Result<TokenInfoWithAddress> {
-        if let Some(info) = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(self.client.get_token_info(address))
-        })? {
-            Ok(info)
-        } else {
-            self.inner.try_fetch_token_info(address)
-        }
+    fn try_fetch_token_info(
+        &self,
+        address: Address,
+    ) -> Pin<Box<dyn Future<Output = eyre::Result<TokenInfoWithAddress>> + Send + '_>> {
+        Box::pin(async move {
+            if let Some(info) = self.client.get_token_info(address).await? {
+                Ok(info)
+            } else {
+                self.inner.try_fetch_token_info(address).await
+            }
+        })
     }
 
     fn protocols_created_before(
@@ -687,14 +692,17 @@ impl<I: LibmdbxInit> LibmdbxReader for ReadOnlyMiddleware<I> {
         self.inner.get_dex_quotes(block)
     }
 
-    fn try_fetch_token_info(&self, address: Address) -> eyre::Result<TokenInfoWithAddress> {
-        if let Some(info) = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(self.client.get_token_info(address))
-        })? {
-            Ok(info)
-        } else {
-            self.inner.try_fetch_token_info(address)
-        }
+    fn try_fetch_token_info(
+        &self,
+        address: Address,
+    ) -> Pin<Box<dyn Future<Output = eyre::Result<TokenInfoWithAddress>> + Send + '_>> {
+        Box::pin(async move {
+            if let Some(info) = self.client.get_token_info(address).await? {
+                Ok(info)
+            } else {
+                self.inner.try_fetch_token_info(address).await
+            }
+        })
     }
 
     fn protocols_created_before(

--- a/crates/brontes-database/brontes-db/src/clickhouse/queries/token_info.sql
+++ b/crates/brontes-database/brontes-db/src/clickhouse/queries/token_info.sql
@@ -1,0 +1,8 @@
+SELECT
+    address,
+    symbol,
+    decimals
+FROM brontes.token_info
+WHERE address = ?
+LIMIT 1
+

--- a/crates/brontes-database/brontes-db/src/libmdbx/libmdbx_read_write.rs
+++ b/crates/brontes-database/brontes-db/src/libmdbx/libmdbx_read_write.rs
@@ -513,16 +513,8 @@ impl LibmdbxReader for LibmdbxReadWriter {
     }
 
     #[brontes_macros::metrics_call(ptr=metrics,scope, db_read, "try_fetch_token_info")]
-    fn try_fetch_token_info(
-        &self,
-        og_address: Address,
-    ) -> impl Future<Output = eyre::Result<TokenInfoWithAddress>> + Send {
-        async move {
-            let address = if constants::ETH_ADDRESSES.contains(&og_address) {
-                constants::WETH_ADDRESS
-            } else {
-                og_address
-            };
+    fn try_fetch_token_info(&self, og_address: Address) -> eyre::Result<TokenInfoWithAddress> {
+        let address = if constants::ETH_ADDRESSES.contains(&og_address) { constants::WETH_ADDRESS } else { og_address };
 
         self.db
             .view_db(|tx| match self.cache.token_info(true, |lock| lock.get(&address)) {
@@ -553,7 +545,6 @@ impl LibmdbxReader for LibmdbxReadWriter {
                     })
                     .ok_or_else(|| eyre::eyre!("entry for key {:?} in TokenDecimals", address)),
             })
-        }
     }
 
     #[brontes_macros::metrics_call(ptr=metrics,scope,db_read,"try_fetch_searcher_eoa_infos")]

--- a/crates/brontes-database/brontes-db/src/libmdbx/libmdbx_read_write.rs
+++ b/crates/brontes-database/brontes-db/src/libmdbx/libmdbx_read_write.rs
@@ -513,8 +513,16 @@ impl LibmdbxReader for LibmdbxReadWriter {
     }
 
     #[brontes_macros::metrics_call(ptr=metrics,scope, db_read, "try_fetch_token_info")]
-    fn try_fetch_token_info(&self, og_address: Address) -> eyre::Result<TokenInfoWithAddress> {
-        let address = if constants::ETH_ADDRESSES.contains(&og_address) { constants::WETH_ADDRESS } else { og_address };
+    fn try_fetch_token_info(
+        &self,
+        og_address: Address,
+    ) -> impl Future<Output = eyre::Result<TokenInfoWithAddress>> + Send {
+        async move {
+            let address = if constants::ETH_ADDRESSES.contains(&og_address) {
+                constants::WETH_ADDRESS
+            } else {
+                og_address
+            };
 
         self.db
             .view_db(|tx| match self.cache.token_info(true, |lock| lock.get(&address)) {
@@ -545,6 +553,7 @@ impl LibmdbxReader for LibmdbxReadWriter {
                     })
                     .ok_or_else(|| eyre::eyre!("entry for key {:?} in TokenDecimals", address)),
             })
+        }
     }
 
     #[brontes_macros::metrics_call(ptr=metrics,scope,db_read,"try_fetch_searcher_eoa_infos")]

--- a/crates/brontes-types/src/db/traits/read.rs
+++ b/crates/brontes-types/src/db/traits/read.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::Address;
+use futures::Future;
 
 use crate::{
     db::{
@@ -107,11 +108,15 @@ pub trait LibmdbxReader: Send + Sync + Unpin + 'static {
 
     fn get_dex_quotes(&self, block: u64) -> eyre::Result<DexQuotes>;
 
-    fn try_fetch_token_info(&self, address: Address) -> eyre::Result<TokenInfoWithAddress>;
+    fn try_fetch_token_info(
+        &self,
+        address: Address,
+    ) -> impl Future<Output = eyre::Result<TokenInfoWithAddress>> + Send;
 
-    fn try_fetch_token_decimals(&self, address: Address) -> eyre::Result<u8> {
-        self.try_fetch_token_info(address).map(|info| info.decimals)
-    }
+    fn try_fetch_token_decimals(
+        &self,
+        address: Address,
+    ) -> impl Future<Output = eyre::Result<u8>> + Send;
 
     fn try_fetch_mev_blocks(
         &self,

--- a/crates/brontes-types/src/db/traits/read.rs
+++ b/crates/brontes-types/src/db/traits/read.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::Address;
-use futures::Future;
 
 use crate::{
     db::{
@@ -108,15 +107,11 @@ pub trait LibmdbxReader: Send + Sync + Unpin + 'static {
 
     fn get_dex_quotes(&self, block: u64) -> eyre::Result<DexQuotes>;
 
-    fn try_fetch_token_info(
-        &self,
-        address: Address,
-    ) -> impl Future<Output = eyre::Result<TokenInfoWithAddress>> + Send;
+    fn try_fetch_token_info(&self, address: Address) -> eyre::Result<TokenInfoWithAddress>;
 
-    fn try_fetch_token_decimals(
-        &self,
-        address: Address,
-    ) -> impl Future<Output = eyre::Result<u8>> + Send;
+    fn try_fetch_token_decimals(&self, address: Address) -> eyre::Result<u8> {
+        self.try_fetch_token_info(address).map(|info| info.decimals)
+    }
 
     fn try_fetch_mev_blocks(
         &self,


### PR DESCRIPTION
## Summary
- read token info from clickhouse instead of only LMDB
- expose query to fetch token info in db client
- add SQL file for token_info table
- remove default body from `try_fetch_token_decimals` trait method

## Testing
- `cargo build --workspace --all-features` *(interrupted)*
- `cargo fmt --all` *(failed: rustfmt errors due to missing generated file)*

------
https://chatgpt.com/codex/tasks/task_e_68414286d314832f8b5ee1db6c9adaf5