### PR TITLE
Add abnormal profit histogram metric

### DIFF
--- a/crates/brontes-inspect/src/mev_inspectors/atomic_arb.rs
+++ b/crates/brontes-inspect/src/mev_inspectors/atomic_arb.rs
@@ -256,6 +256,9 @@ impl<DB: LibmdbxReader> AtomicArbInspector<'_, DB> {
 
         if profit_usd.abs() > 100.0 {
             tracing::warn!(?header.tx_hash, ?profit_usd, "abnormal profit for arb type: {}", possible_arb_type);
+            self.utils.get_profit_metrics().inspect(|m| {
+                m.publish_abnormal_profit(MevType::AtomicArb, protocols.clone(), profit_usd);
+            });
         }
 
         self.utils.get_profit_metrics().inspect(|m| {


### PR DESCRIPTION
## Summary
- track abnormal profit with a new Prometheus histogram
- log abnormal profit in the atomic arbitrage inspector

## Testing
- `cargo check` *(fails: build aborted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6844234de490832f8db1d7201cedc562