### PR TITLE
Dex Volumes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "brontes-tracing",
  "brontes-types",
  "cfg-if",
+ "chrono",
  "clap",
  "clickhouse",
  "colored",

--- a/crates/brontes-database/brontes-db/src/clickhouse/dbms.rs
+++ b/crates/brontes-database/brontes-db/src/clickhouse/dbms.rs
@@ -1,7 +1,7 @@
 use brontes_types::{
     db::{
         address_to_protocol_info::ProtocolInfoClickhouse, block_analysis::BlockAnalysis,
-        dex::DexQuotesWithBlockNumber, normalized_actions::TransactionRoot,
+        dex::{DexQuotesWithBlockNumber, DexVolume}, normalized_actions::TransactionRoot,
         token_info::TokenInfoWithAddress, DbDataWithRunId, RunId,
     },
     mev::*,
@@ -26,7 +26,8 @@ clickhouse_dbms!(
         BrontesToken_Info,
         EthereumPools,
         BrontesTree,
-        BrontesRun_Id
+        BrontesRun_Id,
+        DexDex_Volumes
     ]
 );
 
@@ -152,6 +153,13 @@ remote_clickhouse_table!(
     "crates/brontes-database/brontes-db/src/clickhouse/tables/"
 );
 
+remote_clickhouse_table!(
+    BrontesClickhouseTables,
+    [Dex, Dex_Volumes],
+    DexVolume,
+    "crates/brontes-database/brontes-db/src/clickhouse/tables/"
+);
+
 pub struct BrontesClickhouseData {
     pub data:         BrontesClickhouseTableDataTypes,
     pub force_insert: bool,
@@ -243,5 +251,6 @@ db_types!(
     (ProtocolInfoClickhouse, EthereumPools, false),
     (TransactionRoot, BrontesTree, true),
     (BlockAnalysis, BrontesBlock_Analysis, true),
-    (RunId, BrontesRun_Id, false)
+    (RunId, BrontesRun_Id, false),
+    (DexVolume, DexDex_Volumes, false)
 );

--- a/crates/brontes-database/brontes-db/src/clickhouse/http_client.rs
+++ b/crates/brontes-database/brontes-db/src/clickhouse/http_client.rs
@@ -81,7 +81,7 @@ impl ClickhouseHandle for ClickhouseHttpClient {
         _: BlockHash,
         _: Vec<TxHash>,
         quote_asset: Address,
-        include_relay: bool,
+        _include_relay: bool,
     ) -> eyre::Result<Metadata> {
         let block_meta = self
             .query_many_range::<BlockInfo, BlockInfoData>(block_num, block_num + 1)
@@ -122,7 +122,7 @@ impl ClickhouseHandle for ClickhouseHttpClient {
                 eth_price.unwrap_or_default(),
                 block_meta.value.private_flow.into_iter().collect(),
             );
-            metadata.into_metadata(cex_quotes.value, dex_quotes, None, None)
+            metadata.into_metadata(cex_quotes.value, dex_quotes, None, None, None)
         })
     }
 

--- a/crates/brontes-database/brontes-db/src/clickhouse/middleware.rs
+++ b/crates/brontes-database/brontes-db/src/clickhouse/middleware.rs
@@ -7,7 +7,7 @@ use brontes_types::{
         address_to_protocol_info::ProtocolInfo,
         block_analysis::BlockAnalysis,
         builder::BuilderInfo,
-        dex::DexQuotes,
+        dex::{DexQuotes, DexVolume},
         metadata::Metadata,
         mev_block::MevBlockWithClassified,
         searcher::SearcherInfo,
@@ -64,6 +64,11 @@ impl<I: DBWriter + Send + Sync> DBWriter for ClickhouseMiddleware<I> {
             .await?;
 
         self.inner().write_dex_quotes(block_number, quotes).await
+    }
+
+    async fn write_dex_volumes(&self, volumes: Vec<DexVolume>) -> eyre::Result<()> {
+        self.client.write_dex_volumes(volumes.clone()).await?;
+        self.inner().write_dex_volumes(volumes).await
     }
 
     async fn write_token_info(
@@ -418,6 +423,10 @@ impl<I: DBWriter + Send + Sync> DBWriter for ReadOnlyMiddleware<I> {
         self.client
             .write_dex_quotes(block_number, quotes.clone())
             .await
+    }
+
+    async fn write_dex_volumes(&self, volumes: Vec<DexVolume>) -> eyre::Result<()> {
+        self.client.write_dex_volumes(volumes).await
     }
 
     async fn write_token_info(

--- a/crates/brontes-database/brontes-db/src/clickhouse/split_db.rs
+++ b/crates/brontes-database/brontes-db/src/clickhouse/split_db.rs
@@ -132,7 +132,8 @@ impl ClickhouseBuffered {
             (EthereumPools, ProtocolInfoClickhouse),
             (BrontesTree, TransactionRoot),
             (BrontesBlock_Analysis, BlockAnalysis),
-            (BrontesRun_Id, RunId)
+            (BrontesRun_Id, RunId),
+            (DexDex_Volumes, DexVolume)
         );
 
         Ok(())

--- a/crates/brontes-database/brontes-db/src/clickhouse/tables/dex_volumes.sql
+++ b/crates/brontes-database/brontes-db/src/clickhouse/tables/dex_volumes.sql
@@ -1,7 +1,6 @@
 CREATE TABLE IF NOT EXISTS dex.dex_volumes (
-    `period` DateTime64(3, 'UTC'),
-    `project` String,
-    `volume_usd` Nullable(Float64) DEFAULT 0,
-    `recipient` Nullable(UInt64) DEFAULT 0
-) ENGINE = ReplacingMergeTree()
-ORDER BY (`period`, `project`)
+    `block_number` UInt64,
+    `protocol` String,
+    `volume_usd` Float64
+) ENGINE = MergeTree()
+ORDER BY (`block_number`, `protocol`)

--- a/crates/brontes-database/brontes-db/src/libmdbx/libmdbx_writer.rs
+++ b/crates/brontes-database/brontes-db/src/libmdbx/libmdbx_writer.rs
@@ -12,7 +12,7 @@ use brontes_types::{
         address_metadata::AddressMetadata,
         address_to_protocol_info::ProtocolInfo,
         builder::BuilderInfo,
-        dex::{make_key, DexQuoteWithIndex, DexQuotes},
+        dex::{make_key, DexQuoteWithIndex, DexQuotes, DexVolume},
         initialized_state::{DATA_PRESENT, DEX_PRICE_FLAG, TRACE_FLAG},
         mev_block::MevBlockWithClassified,
         pool_creation_block::PoolsToAddresses,
@@ -454,6 +454,10 @@ impl LibmdbxWriter {
             }
         }
 
+        Ok(())
+    }
+
+    fn write_dex_volumes(&mut self, _volumes: Vec<DexVolume>) -> eyre::Result<()> {
         Ok(())
     }
 

--- a/crates/brontes-types/src/db/dex.rs
+++ b/crates/brontes-types/src/db/dex.rs
@@ -25,7 +25,7 @@ use crate::{
     db::{clickhouse_serde::dex::dex_quote, redefined_types::malachite::RationalRedefined},
     implement_table_value_codecs_with_zc,
     pair::{Pair, PairRedefined},
-    FastHashMap,
+    FastHashMap, Protocol,
 };
 
 /// Represents the DEX prices of a token pair before (`pre_state`) and after a
@@ -454,4 +454,11 @@ impl DexQuotesWithBlockNumber {
             .map(|(i, quote)| DexQuotesWithBlockNumber { block_number, tx_idx: i as u64, quote })
             .collect_vec()
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Row, Eq, Deserialize, Serialize)]
+pub struct DexVolume {
+    pub block_number: u64,
+    pub protocol:     Protocol,
+    pub volume_usd:   f64,
 }

--- a/crates/brontes-types/src/db/traits/write.rs
+++ b/crates/brontes-types/src/db/traits/write.rs
@@ -3,8 +3,11 @@ use futures::Future;
 
 use crate::{
     db::{
-        address_metadata::AddressMetadata, block_analysis::BlockAnalysis, builder::BuilderInfo,
-        dex::DexQuotes, searcher::SearcherInfo,
+        address_metadata::AddressMetadata,
+        block_analysis::BlockAnalysis,
+        builder::BuilderInfo,
+        dex::{DexQuotes, DexVolume},
+        searcher::SearcherInfo,
     },
     mev::{Bundle, MevBlock},
     normalized_actions::Action,
@@ -32,6 +35,13 @@ pub trait DBWriter: Send + Unpin + 'static {
         quotes: Option<DexQuotes>,
     ) -> impl Future<Output = eyre::Result<()>> + Send {
         self.inner().write_dex_quotes(block_number, quotes)
+    }
+
+    fn write_dex_volumes(
+        &self,
+        volumes: Vec<DexVolume>,
+    ) -> impl Future<Output = eyre::Result<()>> + Send {
+        self.inner().write_dex_volumes(volumes)
     }
 
     fn write_token_info(


### PR DESCRIPTION
## Summary
- remove Dex volume CLI and integrate on-chain swap volume tracking
- compute per-protocol swap volume in USD after classification and insert into ClickHouse
- expose new `write_dex_volumes` path and ClickHouse table

## Testing
- `cargo test -p brontes --no-run` *(incomplete: build in progress)*
- `cargo test -p brontes-types --no-run` *(incomplete: build in progress)*
- `cargo test -p brontes-database --no-run` *(incomplete: build in progress)*

------
https://chatgpt.com/codex/tasks/task_e_68ad155501e8832fa114d8718989a379